### PR TITLE
Fix stale apt mirror in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,9 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Install platform dependencies
-        run: sudo apt-get install -y rclone
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rclone
 
       - name: Check black
         run: poetry run black src/ --check


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installation reliability by refreshing the system package index before installing `rclone` in automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->